### PR TITLE
Fix Clozure Common LISP build error

### DIFF
--- a/ast-diff/ast-diff.lisp
+++ b/ast-diff/ast-diff.lisp
@@ -305,7 +305,7 @@ then the equality of the hashes is unlikely."))
                      13913708511125320 47256219783059968)))
       (p 13211719))
 
-  (declare (type (and simple-array (vector hash-type 32)) a-coeffs b-coeffs))
+  (declare (type (or simple-array (vector hash-type 32)) a-coeffs b-coeffs))
 
   ;; functions, methods defined here can use a-coeffs, b-coeffs
   ;; at lower cost than special variables


### PR DESCRIPTION
Previously, the build would fail with the following error:

Error of type TYPE-ERROR: The value
<VECTOR 32 type (UNSIGNED-BYTE 64), simple> is not of the expected
type (SIMPLE-ARRAY (MOD 72057594037927931) (32)).

This commit loosens the type specification to allow for successful
compilation.