### PR TITLE
Adaptations to current Eclector version in software/lisp

### DIFF
--- a/software/parseable.lisp
+++ b/software/parseable.lisp
@@ -85,7 +85,7 @@
              :documentation "Root node of AST.")
    (asts     :initarg :asts :reader asts
              :initform nil :copier :direct
-             :type #+sbcl (list (cons keyword *) *) #-sbcl list
+             :type #+sbcl (or null (cons (cons keyword *) *)) #-sbcl list
              :documentation
              "List of all ASTs.
 See the documentation of `update-asts' for required invariants.")


### PR DESCRIPTION
It compiles and seems to work as intended according to visual inspection (using McCLIM's clouseau) of the result of

``` common-lisp
(parse-asts
 (from-string (make-instance 'lisp)
          "(defun foo () (let ((a 1)) #.(+ 1 2)))"))
```

Might fix some of the issues in #10.